### PR TITLE
removed FF incompatible translation

### DIFF
--- a/pages/_title.php
+++ b/pages/_title.php
@@ -51,7 +51,6 @@ $data = [
     "भाषांतर",
     "terjemahan",
     "traduzzjoni",
-    "ဘာသာပြန်ချက်",
     "अनुवाद",
     "Vertaling",
     "Oversettelse",


### PR DESCRIPTION
dieser key kann im FF nicht dargestellt werden. ich sehe "kästchen" auf github als auch im redaxo.org backend in der installation

![image](https://cloud.githubusercontent.com/assets/120441/23301110/c28f21ee-fa88-11e6-931c-6366f143b0b6.png)
